### PR TITLE
Check product visibility

### DIFF
--- a/wc-mnm-categories.php
+++ b/wc-mnm-categories.php
@@ -434,6 +434,7 @@ class WC_MNM_Categories {
 				'orderby'  => 'title',
 				'order'    => 'ASC',
 				'return'   => 'ids',
+				'visibility' => 'visible',
 				'limit'    => -1
 			)
 		);


### PR DESCRIPTION
We had some products set to `Catalog visibility: Hidden` which where made visible by this plugin.
This change will hide anything that isn't set to `Shop and Search Results`